### PR TITLE
remove natspec sublink and set to main branch

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -18,8 +18,7 @@
     * [Proposal Lifecycle](user-guides/user-guides/multisig-dao/proposal-lifecycle/README.md)
       * [rootDAO Proposal Lifecycle](user-guides/user-guides/multisig-dao/proposal-lifecycle/root-dao-proposal-lifecycle.md)
       * [subDAO Proposal Lifecycle](user-guides/user-guides/multisig-dao/proposal-lifecycle/sub-dao-proposal-lifecycle.md)
-* [Smart Contracts](https://github.com/decent-dao/fractal-contracts/blob/develop/README.md)
-  * [NatSpec](https://github.com/decent-dao/fractal-contracts/tree/develop/docs)
+* [Smart Contracts](https://github.com/decent-dao/fractal-contracts/blob/main/README.md)
 * [FAQ](user-guides/faq.md)
 
 ---


### PR DESCRIPTION
this will link to the proper contracts README once we've merged them to main